### PR TITLE
Auth key as header

### DIFF
--- a/Examples/Example01.cpp
+++ b/Examples/Example01.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string Key = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string Key = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string version;
 
     //write value to version

--- a/Examples/Example02.cpp
+++ b/Examples/Example02.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string Key = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string Key = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string version;
 
     //write value to version

--- a/Examples/Example03.cpp
+++ b/Examples/Example03.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string Key = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string Key = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string season;
 
     //write value to season

--- a/Examples/Example04.cpp
+++ b/Examples/Example04.cpp
@@ -14,17 +14,17 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
-    std::string districtKey = "2017pch"
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string districtKey = "2017pch";
     std::vector<std::string> events;
 
     //write values to events
     districtEvents(request, authKey, districtKey, events);
 
     //write values to standard output
-    for (vector<string>::iterator i = events.begin(); i != events.end(); i++)
+    for (std::vector<std::string>::iterator i = events.begin(); i != events.end(); i++)
     {
-    	cout << *i << endl;
+    	std::cout << *i << std::endl;
     }
 
     return 0;

--- a/Examples/Example05.cpp
+++ b/Examples/Example05.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string districtKey = "2017pch";
     std::vector<std::string> teams;
 

--- a/Examples/Example06.cpp
+++ b/Examples/Example06.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string eventKey = "2017gagai";
     std::vector<std::string> teams;
 

--- a/Examples/Example07.cpp
+++ b/Examples/Example07.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string eventKey = "2017gagai";
     std::map<std::string, std::string> stats;
 

--- a/Examples/Example08.cpp
+++ b/Examples/Example08.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string eventKey = "2017gagai";
     std::map<std::string, std::string> stats;
 

--- a/Examples/Example09.cpp
+++ b/Examples/Example09.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string eventKey = "2017gagai";
     std::map<std::string, std::string> stats;
 

--- a/Examples/Example10.cpp
+++ b/Examples/Example10.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string eventKey = "2017gagai";
     std::vector<std::string> matches;
 

--- a/Examples/Example11.cpp
+++ b/Examples/Example11.cpp
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string teamKey = "frc4112";
     std::string district;
 

--- a/Examples/Example12.cpp
+++ b/Examples/Example12.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string teamKey = "frc4112";
     std::vector<std::string> events;
 

--- a/Examples/Example13.cpp
+++ b/Examples/Example13.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string teamKey = "frc4112";
     std::vector<std::string> events;
 

--- a/Examples/Example14.cpp
+++ b/Examples/Example14.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string teamKey = "frc4112";
     std::string eventKey = "2017gagai";
     std::vector<std::string> matches;

--- a/Examples/Example15.cpp
+++ b/Examples/Example15.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string teamKey = "frc4112";
     std::string eventKey = "2017gagai";
     std::vector<std::string> awards;

--- a/Examples/Example16.cpp
+++ b/Examples/Example16.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string matchKey = "2017gagai_qm1";
     std::vector<std::string> teams;
 

--- a/Examples/Example17.cpp
+++ b/Examples/Example17.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string matchKey = "2017gagai_qm1";
     std::string teamKey = "frc5734";
     bool disqualified;

--- a/Examples/Example18.cpp
+++ b/Examples/Example18.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string matchKey = "2017gagai_qm9";
     std::string teamKey = "frc4112";
     std::string points;

--- a/Examples/Example19.cpp
+++ b/Examples/Example19.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string matchKey = "2017gagai_qm9";
     std::string teamKey = "frc4112";
     std::string points;

--- a/Examples/Example20.cpp
+++ b/Examples/Example20.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string matchKey = "2017gagai_qm9";
     std::string teamKey = "frc4112";
     std::string points;

--- a/Examples/Example21.cpp
+++ b/Examples/Example21.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string matchKey = "2017gagai_qm1";
     std::string teamKey = "frc5734";
     std::string foul;

--- a/Examples/Example22.cpp
+++ b/Examples/Example22.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string matchKey = "2017gagai_qm1";
     std::string teamKey = "frc5734";
     std::string foul;

--- a/Examples/Example23.cpp
+++ b/Examples/Example23.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string matchKey = "2017gagai_qm1";
     std::string teamKey = "frc1311";
     std::string points;

--- a/Examples/Example24.cpp
+++ b/Examples/Example24.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string matchKey = "2017gagai_qm9";
     std::vector<std::string> teams;
 

--- a/Examples/Example25.cpp
+++ b/Examples/Example25.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string matchKey = "2017gagai_qm9";
     std::vector<std::string> teams;
 

--- a/Examples/Example26.cpp
+++ b/Examples/Example26.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string matchKey = "2017gagai_qm9";
     std::string teamKey = "frc4112";
     bool won;

--- a/Examples/Example27.cpp
+++ b/Examples/Example27.cpp
@@ -19,7 +19,7 @@ int main(int argc, char *argv[])
 {
     //declare variables
     curlpp::Easy request;
-    std::string authKey = "?X-TBA-Auth-Key=H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
+    std::string authKey = "H5B8Nt9mX2aFB3LocyRrZEpF7y9XwIWBST3tJRO0cOcqqs4AMwyl71K7zdFNlp16";
     std::string eventKey = "2017gagai";
     std::vector<std::string> teamKeys;
 

--- a/src/TBAdistrict.cpp
+++ b/src/TBAdistrict.cpp
@@ -4,8 +4,8 @@ using namespace std;
 bool districtEvents(curlpp::Easy& request, const std::string& AuthKey, const std::string& districtKey, std::vector<std::string>& events)
 {
 	// gets all the events in a district
-    string url = "https://www.thebluealliance.com/api/v3/district/" + districtKey + "/events/keys" + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/district/" + districtKey + "/events/keys";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parse(response, "\"", "\"", events);
@@ -20,8 +20,8 @@ bool districtEvents(curlpp::Easy& request, const std::string& AuthKey, const std
 bool districtTeams(curlpp::Easy& request, const std::string& AuthKey, const std::string& districtKey, std::vector<std::string>& teams)
 {
 	// gets all the teams in a district
-    string url = "https://www.thebluealliance.com/api/v3/district/" + districtKey + "/teams/keys" + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/district/" + districtKey + "/teams/keys";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parse(response, "\"", "\"", teams);

--- a/src/TBAevent.cpp
+++ b/src/TBAevent.cpp
@@ -4,8 +4,8 @@ using namespace std;
 bool teamsAtEvent(curlpp::Easy& request, const std::string& AuthKey, const std::string& eventKey, std::vector<std::string>& teams)
 {
 	// gets all the teams at an event
-    string url = "https://www.thebluealliance.com/api/v3/event/" + eventKey + "/teams/keys" + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/event/" + eventKey + "/teams/keys";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parse(response, "\"", "\"", teams);
@@ -19,8 +19,8 @@ bool teamsAtEvent(curlpp::Easy& request, const std::string& AuthKey, const std::
 bool opr(curlpp::Easy& request, const std::string& AuthKey, const std::string& eventKey, std::map<std::string, std::string>& oprs)
 {
 	// gets a map of the team keys and oprs of all the teams at an event
-    string url = "https://www.thebluealliance.com/api/v3/event/" + eventKey + "/oprs" + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/event/" + eventKey + "/oprs";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
         string opr = "";
@@ -36,8 +36,8 @@ bool opr(curlpp::Easy& request, const std::string& AuthKey, const std::string& e
 bool dpr(curlpp::Easy& request, const std::string& AuthKey, const std::string& eventKey, std::map<std::string, std::string>& dprs)
 {
 	// gets a map of the team keys and dprs of all the teams at an event
-    string url = "https://www.thebluealliance.com/api/v3/event/" + eventKey + "/oprs" + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/event/" + eventKey + "/oprs";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
         string dpr = "";
@@ -53,8 +53,8 @@ bool dpr(curlpp::Easy& request, const std::string& AuthKey, const std::string& e
 bool ccwm(curlpp::Easy& request, const std::string& AuthKey, const std::string& eventKey, std::map<std::string, std::string>& ccwms)
 {
 	// gets a map of the team keys and ccwms of all the teams at an event
-    string url = "https://www.thebluealliance.com/api/v3/event/" + eventKey + "/oprs" + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/event/" + eventKey + "/oprs";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
         string ccwm = "";
@@ -70,8 +70,8 @@ bool ccwm(curlpp::Easy& request, const std::string& AuthKey, const std::string& 
 bool matchesAtEvent(curlpp::Easy& request, const std::string& AuthKey, const std::string& eventKey, std::vector<std::string>& matches)
 {
 	// gets all the matchKeys of an event
-    string url = "https://www.thebluealliance.com/api/v3/event/" + eventKey + "/matches/keys" + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/event/" + eventKey + "/matches/keys";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parse(response, "\"", "\"", matches);

--- a/src/TBAinternal.cpp
+++ b/src/TBAinternal.cpp
@@ -1,13 +1,16 @@
 #include "TBAinternal.hpp"
 using namespace std;
 
-string performtostring(curlpp::Easy& request, string& url)
+string performtostring(curlpp::Easy& request, string& url,const string& AuthKey)
 {
   //returns TBA response as string to be parsed
   try {
     string userAgent = "4112-Cpp-Scouting/1.0.1 https://goo.gl/RLJpkt";
+    list<string> header;
+    header.push_back("X-TBA-Auth-Key: " + AuthKey);
     request.setOpt(new curlpp::options::Url(url));
     request.setOpt(new curlpp::options::UserAgent(userAgent));
+    request.setOpt(new curlpp::options::HttpHeader(header));
     ostringstream requeststream;
     request.setOpt(new curlpp::options::WriteStream(&requeststream));
     request.perform();

--- a/src/TBAinternal.hpp
+++ b/src/TBAinternal.hpp
@@ -10,7 +10,7 @@
 #include "curlpp/Options.hpp"
 #include "curlpp/Exception.hpp"
 
-std::string performtostring(curlpp::Easy& request, std::string& url);
+std::string performtostring(curlpp::Easy& request, std::string& url, const std::string& AuthKey);
 // returns TBA response as string to be parsed
 bool parse(std::string& response, std::string seperator, std::string& value);
 // use to parse for value after FIRST occurence of seperator

--- a/src/TBAmatch.cpp
+++ b/src/TBAmatch.cpp
@@ -4,8 +4,8 @@ using namespace std;
 bool disqualifiedTeams(curlpp::Easy& request, const std::string& AuthKey, const std::string& matchKey, std::vector<std::string>& teams)
 {
 	// gets a vector of all teams disqualified in a match
-    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey;
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
         string disblue;
@@ -24,8 +24,8 @@ bool disqualifiedTeams(curlpp::Easy& request, const std::string& AuthKey, const 
 bool wasDisqualified(curlpp::Easy& request, const std::string& AuthKey, const std::string& matchKey, const std::string& teamKey, bool& disqualified)
 {
 	// gets if a specific team was disqualified from a match
-    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey;
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		string disblue;
@@ -44,8 +44,8 @@ bool wasDisqualified(curlpp::Easy& request, const std::string& AuthKey, const st
 bool autoPoints(curlpp::Easy& request, const std::string& AuthKey, const std::string& matchKey, const std::string& teamKey, std::string& points)
 {
 	// gets the auto points of an alliance in a match
-    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey;
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		string blue;
@@ -79,8 +79,8 @@ bool autoPoints(curlpp::Easy& request, const std::string& AuthKey, const std::st
 bool teleopPoints(curlpp::Easy& request, const std::string& AuthKey, const std::string& matchKey, const std::string& teamKey, std::string& points)
 {
 	// gets the teleop points of an alliance in a match
-    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey;
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		string blue;
@@ -114,8 +114,8 @@ bool teleopPoints(curlpp::Easy& request, const std::string& AuthKey, const std::
 bool totalPoints(curlpp::Easy& request, const std::string& AuthKey, const std::string& matchKey, const std::string& teamKey, std::string& points)
 {
 	// gets the total points of an alliance in a match
-    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey;
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		string blue;
@@ -149,8 +149,8 @@ bool totalPoints(curlpp::Easy& request, const std::string& AuthKey, const std::s
 bool foulCount(curlpp::Easy& request, const std::string& AuthKey, const std::string& matchKey, const std::string& teamKey, std::string& fouls)
 {
 	// gets the number of fouls caused by an alliance in a match
-    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey;
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		string blue;
@@ -184,8 +184,8 @@ bool foulCount(curlpp::Easy& request, const std::string& AuthKey, const std::str
 bool techFoulCount(curlpp::Easy& request, const std::string& AuthKey, const std::string& matchKey, const std::string& teamKey, std::string& fouls)
 {
 	// gets the number of tech fouls caused by an alliance in a match
-    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey;
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		string blue;
@@ -219,8 +219,8 @@ bool techFoulCount(curlpp::Easy& request, const std::string& AuthKey, const std:
 bool foulPoints(curlpp::Easy& request, const std::string& AuthKey, const std::string& matchKey, const std::string& teamKey, std::string& points)
 {
 	// gets the number of points an alliance recieved from fouls
-    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey;
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		string blue;
@@ -254,8 +254,8 @@ bool foulPoints(curlpp::Easy& request, const std::string& AuthKey, const std::st
 bool winners(curlpp::Easy& request, const std::string& AuthKey, const std::string& matchKey, std::vector<std::string>& teams)
 {
 	// gets the teamKeys of the winners of a match
-    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey;
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		string winningAlliance;
@@ -287,8 +287,8 @@ bool winners(curlpp::Easy& request, const std::string& AuthKey, const std::strin
 bool losers(curlpp::Easy& request, const std::string& AuthKey, const std::string& matchKey, std::vector<std::string>& teams)
 {
 	// gets the teamKeys of the losers of a match
-    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey;
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		string winningAlliance;
@@ -320,8 +320,8 @@ bool losers(curlpp::Easy& request, const std::string& AuthKey, const std::string
 bool didWin(curlpp::Easy& request, const std::string& AuthKey, const std::string& matchKey, const std::string& teamKey, bool& win)
 {
 	// gets whether or not a team won a match
-    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey + AuthKey;
-	string response = performtostring(request, url);
+    string url = "https://www.thebluealliance.com/api/v3/match/" + matchKey;
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		string winningAlliance;

--- a/src/TBAstatus.cpp
+++ b/src/TBAstatus.cpp
@@ -5,8 +5,8 @@ bool androidVer(curlpp::Easy& request, const std::string& AuthKey, std::string& 
 {
 	//gets the current version of the TBA android app
 	version.resize(7);
-	string url = "https://www.thebluealliance.com/api/v3/status" + AuthKey;
-	string response = performtostring(request, url);
+	string url = "https://www.thebluealliance.com/api/v3/status";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parse(response, "\"latest_app_version\": ", version);
@@ -22,8 +22,8 @@ bool iosVer(curlpp::Easy& request, const std::string& AuthKey, std::string& vers
 {
 	//gets the current version of the TBA ios app
 	version.resize(2);
-	string url = "https://www.thebluealliance.com/api/v3/status" + AuthKey;
-	string response = performtostring(request, url);
+	string url = "https://www.thebluealliance.com/api/v3/status";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parselast(response, "\"latest_app_version\": ", version);
@@ -39,8 +39,8 @@ bool currentSeason(curlpp::Easy& request, const std::string& AuthKey, std::strin
 {
 	//gets the year of the current FRC season
 	season.resize(4);
-	string url = "https://www.thebluealliance.com/api/v3/status" + AuthKey;
-	string response = performtostring(request, url);
+	string url = "https://www.thebluealliance.com/api/v3/status";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parse(response, "\"current_season\": ", season);

--- a/src/TBAteam.cpp
+++ b/src/TBAteam.cpp
@@ -4,8 +4,8 @@ using namespace std;
 bool teamDistrict(curlpp::Easy& request, const std::string& AuthKey, const std::string& teamKey, std::string& district)
 {
 	// gets the district of a team (requires teamKey)
-	string url = "https://www.thebluealliance.com/api/v3/team/" + teamKey + "/districts" + AuthKey;
-	string response = performtostring(request, url);
+	string url = "https://www.thebluealliance.com/api/v3/team/" + teamKey + "/districts";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parselast(response, "\"key\": \"", "\"", district);
@@ -20,8 +20,8 @@ bool teamDistrict(curlpp::Easy& request, const std::string& AuthKey, const std::
 bool teamEvents(curlpp::Easy& request, const std::string& AuthKey, const std::string& teamKey, std::vector<std::string>& events)
 {
 	// gets all event keys a team has or will compete at (requires teamKey)
-  string url = "https://www.thebluealliance.com/api/v3/team/" + teamKey + "/events/keys" + AuthKey;
-	string response = performtostring(request, url);
+  string url = "https://www.thebluealliance.com/api/v3/team/" + teamKey + "/events/keys";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parse(response, "\"", "\"", events);
@@ -36,8 +36,8 @@ bool teamEvents(curlpp::Easy& request, const std::string& AuthKey, const std::st
 bool yearTeamEvents(curlpp::Easy& request, const std::string& AuthKey, const std::string& teamKey, const std::string& year, std::vector<std::string>& events)
 {
 	// gets all event keys from a single FRC season (requires teamKey and year)
-  string url = "https://www.thebluealliance.com/api/v3/team/" + teamKey + "/events/"+ year +"/keys" + AuthKey;
-	string response = performtostring(request, url);
+  string url = "https://www.thebluealliance.com/api/v3/team/" + teamKey + "/events/"+ year +"/keys";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parse(response, "\"", "\"", events);
@@ -52,8 +52,8 @@ bool yearTeamEvents(curlpp::Easy& request, const std::string& AuthKey, const std
 bool teamMatchesAtEvent(curlpp::Easy& request, const std::string& AuthKey, const std::string& teamKey, const std::string& eventKey, std::vector<std::string>& matches)
 {
 	// get a teams match keys at an event (requires teamKey and eventKey)
-	string url = "https://www.thebluealliance.com/api/v3/team/" + teamKey + "/event/"+ eventKey +"/matches/keys" + AuthKey;
-	string response = performtostring(request, url);
+	string url = "https://www.thebluealliance.com/api/v3/team/" + teamKey + "/event/"+ eventKey +"/matches/keys";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parse(response, "\"", "\"", matches);
@@ -68,8 +68,8 @@ bool teamMatchesAtEvent(curlpp::Easy& request, const std::string& AuthKey, const
 bool teamAwardsAtEvent(curlpp::Easy& request, const std::string& AuthKey, const std::string& teamKey, const std::string& eventKey, std::vector<std::string>& awards)
 {
 	// get a teams awards at an event (requires teamKey and eventKey)
-	string url = "https://www.thebluealliance.com/api/v3/team/" + teamKey + "/event/"+ eventKey +"/awards" + AuthKey;
-	string response = performtostring(request, url);
+	string url = "https://www.thebluealliance.com/api/v3/team/" + teamKey + "/event/"+ eventKey +"/awards";
+	string response = performtostring(request, url, AuthKey);
 	if (!parseError(response) && response != "")
 	{
 		parse(response, "\"name\": \"", "\"", awards);


### PR DESCRIPTION
Sends the authorization key in the header of the https request instead of as a URL paramater.

- possible performance speed increase
- as TBA intends